### PR TITLE
changing dependency on srcid to credentialid

### DIFF
--- a/Public/New-AGMLibGCEInstanceDiscovery.ps1
+++ b/Public/New-AGMLibGCEInstanceDiscovery.ps1
@@ -344,7 +344,6 @@ Function New-AGMLibGCEInstanceDiscovery ([string]$discoveryfile,[switch]$nobacku
                 write-host "$ct Processing this selection"
                 $cred
             }
-            # we need to learn the srcid
             $credgrab = ($srccredgrab | where-object {($_.credentialid -eq $cred.credentialid) -and ($_.applianceid -eq $cred.applianceid)})
             if ($credgrab.credentialid)
             {

--- a/Public/New-AGMLibGCEInstanceDiscovery.ps1
+++ b/Public/New-AGMLibGCEInstanceDiscovery.ps1
@@ -329,7 +329,7 @@ Function New-AGMLibGCEInstanceDiscovery ([string]$discoveryfile,[switch]$nobacku
             $ct = Get-Date
             write-host "$ct Running Get-AGMDiskpool"
         }
-        $diskpooldatagrab = Get-AGMDiskpool -filtervalue pooltype=cloud | Select-object name,@{N='srcid';E={$_.cloudcredential.sources.srcid}}
+        $diskpooldatagrab = Get-AGMDiskpool -filtervalue pooltype=cloud
         if ($textoutput)
         {
             $ct = Get-Date
@@ -346,10 +346,10 @@ Function New-AGMLibGCEInstanceDiscovery ([string]$discoveryfile,[switch]$nobacku
             }
             # we need to learn the srcid
             $credgrab = ($srccredgrab | where-object {($_.credentialid -eq $cred.credentialid) -and ($_.applianceid -eq $cred.applianceid)})
-            if ($credgrab.srcid)
+            if ($credgrab.credentialid)
             {
-                $srcid = $credgrab.srcid
-                $diskpoolgrab = $diskpooldatagrab | where-object {($_.srcid -eq $srcid)}
+                $credid = $credgrab.credentialid
+                $diskpoolgrab = $diskpooldatagrab | where-object {($_.cloudcredential.id -eq $credid)}
                 if ($diskpoolgrab.name)
                 {
                     $poolname = $diskpoolgrab.name


### PR DESCRIPTION
This fixes an issue when using multiple appliances (in different regions) that each have their credential. The appliances have a unique `id`, and each appliance is associated with a cloud credential with a unique `id`. However, the `srcid` of the cloud credential is not unique (i.e. different cloud credentials have the same `srcid`). Diskpool objects reference these non-unique `srcid` parameter. However, Diskpool objects of type `cloud` also keeps a reference to the unique `credentialid`, which should be used instead to fetch the appropriate `$slpid` (Profile).

When running the following command (or any command with equivalent effect, with the `-backup` parameter set):

```
New-AGMLibGCEInstanceDiscovery `
    -applianceid 145637973770 `
    -credentialid 4148 `
    -projectid hmcp-tst-cv-sndbx-de-prj-yjv `
    -zone europe-west3-a `
    -backup `
    -usertag backupplan
```

this currently results in `$diskpoolgrab` being an array of objects rather than the specific diskpool to grab on line 349. The effect of that is that when trying to fetch the `$slplookup`, the value of that variable on line 356 is `$null`, and subsequently `$slpid` on line 363 evaluates to `$false`. This causes the function to terminate without having done the discovery, and attached the backup plans as specified in the command.  

The changes implemented ensures that checks are made against the unique `credentialid` instead of the `srcid`